### PR TITLE
Remove unnecessary newline in keybindings.json

### DIFF
--- a/.vscode/keybindings.json
+++ b/.vscode/keybindings.json
@@ -3,6 +3,5 @@
     "key": "ctrl+h",
     "command": "workbench.action.tasks.runTask",
     "args": "Debug Jest Tests"
-    
   }
 ]


### PR DESCRIPTION
Remove an unnecessary newline in the keybindings.json file to maintain cleaner formatting.